### PR TITLE
Final user stories from headline spec from landlord prespective

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -6,39 +6,43 @@ A web application that allows users to list spaces for hire, and to hire spaces 
 As a user,
 so that I can start using Makers BnB,
 I want to register for an account.
-```
-```
+
 As a user,
 so that I can use the site,
 I want to sign in.
 ```
 ```
-As a user,
+As a signed-up user,
 so that I can prevent anyone else using my account,
 I want to sign out.
-```
-```
-As a user,
+
+As a signed-up user,
 so that I can get bookings,
 I want to list my spaces.
-```
-```
+
 As a signed-up user,
 so that my space is findable in a bookings search,
 I want to name my space.
-```
-```
+
 As a signed-up user,
 so that I can make my space sound good and get bookings,
 I want to provide a short description of my space.
-```
-```
+
 As a signed-up user,
 so that I can make money from bookings,
 I want to set a price per night for a particular space.
 ```
+
 ```
 As a signed-up user with a space listed,
 so that I can control when my space gets booked,
 I want to list dates of availability.
+
+As a signed up user with a space listing,
+so that I have a choice whether to take a booking,
+I want to approve a booking before it is confirmed.
+
+As a signed up user with a space listing,
+so that I don't disappoint potential visits,
+I want to mark a night with a confirmed booking as unavailable to others.   
 ```


### PR DESCRIPTION
Any signed-up user can request to hire any space for one night, and this should be approved by the user that owns that space.
Nights for which a space has already been booked should not be available for users to book that space.
Until a user has confirmed a booking request, that space can still be booked for that night.
